### PR TITLE
attachment_filename is replaced with download_name

### DIFF
--- a/Re2Pcap/Re2Pcap.py
+++ b/Re2Pcap/Re2Pcap.py
@@ -133,7 +133,7 @@ def createPcap():
 			time.sleep(5)
 			childProc.communicate()
 			if not childProc.returncode:
-				return send_file('io/Re2Pcap-result.pcap', as_attachment=True, attachment_filename=resultFileName)
+				return send_file('io/Re2Pcap-result.pcap', as_attachment=True, download_name=resultFileName)
 			else:
 				return jsonify(error='Something went Wrong :( Please Check the Input/ Error log and Try Again ....')
 		else:


### PR DESCRIPTION
Updated code for successful downloading of the PCAP file. Currently the code is based on the deprecated method parameter `attachment_filename`. `attachment_filename` is replaced with `download_name` in Flask's send_file method (Please see https://github.com/pallets/flask/issues/4753 for more details).


I would love to maintain this project but since it was removed and re-added under Cisco-Talos, I lost write ability to this repository. Please add write access to me for this repo (or I'll have to go through the pull requests every time I need to make changes to this repo)

Thanks,
Amit Raut